### PR TITLE
Add option to set the payment id manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A wrapper on perfect-money's API
 
 Installation:
 
-	composer require mohsen-nurisa/perfectmoney-laravel
+	composer require nishad-prime/perfectmoney-laravel
 
 Usage: 
 After installaion, execute the line below to publish the ServiceProvider and create necessary tables:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Then you can initiate transfere using line below:
 
 The $params variable must contain the following parameters:
 
+	'payment_id' => the transaction id for the payment which you will receive in the callback. must be unique,
 	'payment_amount' => the amount of payment,
 	'payment_units' => The fiat that you want to use, ex:USD
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mohsen-nurisa/perfectmoney-laravel",
+    "name": "nishad-prime/perfectmoney-laravel",
     "description": "perfectmoney api wrapper for Laravel",
     "keywords": [
         "perfectmoney"

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
         {
             "name": "Mohsen Nurisa",
             "email": "mohsen.nurisa@gmail.com"
+        },
+        {
+            "name": "Nasir Hossain Nishad",
+            "email": "nasir@egitsoft.com"
         }
     ],
     "require": {

--- a/src/Config/perfectmoney.php
+++ b/src/Config/perfectmoney.php
@@ -1,4 +1,5 @@
 <?php 
+
 return [
 	'pm_payee_account' => env('PM_PAYEE_ACCOUNT', ''),
 	'pm_success_callback' => '',
@@ -8,5 +9,3 @@ return [
 	'pm_account_id' => env('PM_ACCOUNT_ID', ''),
 	'pm_account_password' => env('PM_ACCOUNT_PASSWORD', ''),
 ];
-
-?>

--- a/src/Contracts/PerfectmoneyContract.php
+++ b/src/Contracts/PerfectmoneyContract.php
@@ -1,11 +1,11 @@
-<?php  
+<?php
+
 namespace Package\Perfectmoney\Contracts;
 
 /**
  * summary
  */
-abstract class PerfectmoneyContract 
+abstract class PerfectmoneyContract
 {
 
 }
-?>

--- a/src/Controllers/PerfectMoneyController.php
+++ b/src/Controllers/PerfectMoneyController.php
@@ -1,4 +1,5 @@
-<?php  
+<?php
+
 namespace Package\Perfectmoney\Controllers;
 
 use Illuminate\Routing\Controller;
@@ -8,39 +9,38 @@ use Illuminate\Http\Request;
 
 class PerfectMoneyController extends Controller
 {
-	protected $handler;
+    protected $handler;
 
-	public function __construct() 
-	{
-		$this->handler=new Perfectmoney();
-	}
+    public function __construct()
+    {
+        $this->handler = new Perfectmoney();
+    }
 
-	public function sell(Request $request)
-	{
-		$this->validateInitiationRequest($request);
-		return $this->handler->sell($request);
-	}
+    public function sell(Request $request)
+    {
+        $this->validateInitiationRequest($request);
+        return $this->handler->sell($request);
+    }
 
     public function pmSuccess(Request $request)
     {
-    	return $this->handler->pmSuccess($request);
-        
+        return $this->handler->pmSuccess($request);
+
     }
 
     public function pmFail(Request $request)
     {
-       return $this->handler->pmFail($request);
+        return $this->handler->pmFail($request);
 
     }
 
     public function pmStatus(Request $request)
     {
-   		return $this->handler->pmStatus($request);
+        return $this->handler->pmStatus($request);
     }
 
     public function validateInitiationRequest($request)
     {
-    	$request->validate(['payment_amount' => 'required|numeric', 'payment_units' => 'required']);
+        $request->validate(['payment_amount' => 'required|numeric', 'payment_units' => 'required']);
     }
 }
-?>

--- a/src/Database/migrations/2019_10_10_134640_create_perfect_money_transactions_table.php
+++ b/src/Database/migrations/2019_10_10_134640_create_perfect_money_transactions_table.php
@@ -15,7 +15,7 @@ class CreatePerfectMoneyTransactionsTable extends Migration
     {
         Schema::create('perfect_money_transactions', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->enum('status', array('banking','paid','failed','canceled'))->default('banking');
+            $table->enum('status', array('banking', 'paid', 'failed', 'canceled'))->default('banking');
             $table->string('payment_id', 191);
             $table->string('payee_account', 191);
             $table->float('payment_amount');

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -1,24 +1,29 @@
-<?php  
+<?php
+
 namespace Package\Perfectmoney\Exceptions;
+
 use Exception;
 use Illuminate\Notifications\Notification;
 
 class InvalidConfiguration extends Exception
 {
-    public static function emptyPayeeAccount() {
-    	return new self('Payee account parameter cannot be empty. Check perfectmoney config file for details.');
+    public static function emptyPayeeAccount()
+    {
+        return new self('Payee account parameter cannot be empty. Check perfectmoney config file for details.');
     }
 
-    public static function emptyAlternativePassphrase() {
-    	return new self('Alternative passphrase cannot be empty. Check perfectmoney config file for details.');
+    public static function emptyAlternativePassphrase()
+    {
+        return new self('Alternative passphrase cannot be empty. Check perfectmoney config file for details.');
     }
 
-    public static function emptyAccountId() {
-    	return new self('Account ID cannot be empty. Check perfectmoney config file for details.');
+    public static function emptyAccountId()
+    {
+        return new self('Account ID cannot be empty. Check perfectmoney config file for details.');
     }
 
-    public static function emptyAccountPassword() {
-    	return new self('Account password cannot be empty. Check perfectmoney config file for details.');
+    public static function emptyAccountPassword()
+    {
+        return new self('Account password cannot be empty. Check perfectmoney config file for details.');
     }
 }
-?>

--- a/src/Facades/Perfectmoney.php
+++ b/src/Facades/Perfectmoney.php
@@ -1,13 +1,13 @@
-<?php  
+<?php
+
 namespace Package\Perfectmoney\Facades;
+
 use illuminate\Support\Facades\Facade;
 
 class Perfectmoney extends Facade
 {
-
-	protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor()
     {
         return 'perfectmoney';
     }
 }
-?>

--- a/src/Perfectmoney.php
+++ b/src/Perfectmoney.php
@@ -41,19 +41,10 @@ class Perfectmoney extends PerfectmoneyContract
 
         $this->requiredSellParamsCheck($request);
 
-
     	$pmTransaction = new PerfectMoneyTransaction;
-
-    	do {
-    	    $uniqueToken = strtoupper(md5(mt_rand(1000000000, mt_getrandmax())));
-    	} while (PerfectMoneyTransaction::where('payment_id', $uniqueToken)->exists());
-
-    	$pmTransaction->payment_id = $uniqueToken;
-
-    	$pmTransaction->payment_amount=$request->get('payment_amount');
-
+    	$pmTransaction->payment_id    = $request->get('payment_id');
+    	$pmTransaction->payment_amount= $request->get('payment_amount');
     	$pmTransaction->payment_units = strtoupper($request->get('payment_units'));
-
     	$pmTransaction->payee_account = $this->pm_payee_account;
 
     	// $order->save();

--- a/src/Perfectmoney.php
+++ b/src/Perfectmoney.php
@@ -196,7 +196,7 @@ class Perfectmoney extends PerfectmoneyContract
             throw InvalidConfiguration::emptyAlternativePassphrase();
         }
 
-        $request->validate(['payment_amount' => 'required|numeric', 'payment_units' => 'required|string']);
+        $request->validate(['payment_id' => 'required|string', 'payment_amount' => 'required|numeric', 'payment_units' => 'required|string']);
 
     }
 

--- a/src/Perfectmoney.php
+++ b/src/Perfectmoney.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+
 namespace Package\Perfectmoney;
 
 use Auth;
@@ -7,13 +8,12 @@ use Package\Perfectmoney\Contracts\PerfectmoneyContract;
 use Package\Perfectmoney\Exceptions\InvalidConfiguration;
 use Package\Perfectmoney\Models\PerfectMoneyTransaction;
 use Session;
+
 class Perfectmoney extends PerfectmoneyContract
-{	
-    
+{
+
     const CREATE_URL = "https://perfectmoney.is/acct/ev_create.asp";
-    
     const ACTIVATE_URL = "https://perfectmoney.is/acct/ev_activate.asp";
-    
     const RETURN_URL = "https://perfectmoney.is/acct/ev_remove.asp";
 
     protected $pm_payee_account;
@@ -30,35 +30,33 @@ class Perfectmoney extends PerfectmoneyContract
         $this->pm_account_password = config('perfectmoney.pm_account_password');
     }
 
-    public function buy() 
+    public function buy()
     {
-    	
+
     }
 
-    public function sell($params) 
+    public function sell($params)
     {
         $request = new Request($params);
 
         $this->requiredSellParamsCheck($request);
 
-    	$pmTransaction = new PerfectMoneyTransaction;
-    	$pmTransaction->payment_id    = $request->get('payment_id');
-    	$pmTransaction->payment_amount= $request->get('payment_amount');
-    	$pmTransaction->payment_units = strtoupper($request->get('payment_units'));
-    	$pmTransaction->payee_account = $this->pm_payee_account;
+        $pmTransaction = new PerfectMoneyTransaction;
+        $pmTransaction->payment_id = $request->get('payment_id');
+        $pmTransaction->payment_amount = $request->get('payment_amount');
+        $pmTransaction->payment_units = strtoupper($request->get('payment_units'));
+        $pmTransaction->payee_account = $this->pm_payee_account;
 
-    	// $order->save();
-    	$pmTransaction->save();
+        $pmTransaction->save();
 
-    	return ['status'=>'success','action'=>'submit_form','data'=>view('nishad-prime/perfectmoney-laravel::form',compact('pmTransaction'))->render(),'message'=>__('sell_initiated_successfully')];
-
+        return ['status' => 'success', 'action' => 'submit_form', 'data' => view('nishad-prime/perfectmoney-laravel::form', compact('pmTransaction'))->render(), 'message' => __('sell_initiated_successfully')];
     }
 
-    public function redeemVoucher($params) {
+    public function redeemVoucher($params)
+    {
         $request = new Request($params);
 
         $this->requiredRedeemParamsCheck($request);
-
 
         $result = $this->submit(self::ACTIVATE_URL, [
             'Payee_Account' => $this->pm_payee_account,
@@ -67,30 +65,25 @@ class Perfectmoney extends PerfectmoneyContract
         ]);
 
         return $result;
-
     }
 
-    public function pmSuccess(Request $request) 
+    public function pmSuccess(Request $request)
     {
-    	$payment_id = $request->PAYMENT_ID;
+        $payment_id = $request->PAYMENT_ID;
 
-    	$pmTransaction = PerfectMoneyTransaction::where('payment_id', $payment_id)->first();
-    	if(!$pmTransaction){
-    		return abort(404);
-    	}
-
+        $pmTransaction = PerfectMoneyTransaction::where('payment_id', $payment_id)->first();
+        if (!$pmTransaction) {
+            return abort(404);
+        }
 
         if (config('perfectmoney.pm_success_callback')) {
             $callback = config('perfectmoney.pm_success_callback');
             $params = ['status' => 'success', 'payment_id' => $request->PAYMENT_ID];
             $callback($params);
-            // call_user_func_array(config('perfectmoney.pm_success_function'), $params);
-            // call_user_func(config('perfectmoney.pm_success_function'));
             return true;
         }
 
         return ['status' => 'success', 'payment_id' => $request->get('PAYMENT_ID')];
-	    
     }
 
     public function pmFail(Request $request)
@@ -100,15 +93,11 @@ class Perfectmoney extends PerfectmoneyContract
         $pmTransaction = PerfectMoneyTransaction::where('payment_id', $payment_id)->firstOrFail();
 
         if ($pmTransaction->status == 'banking') {
-
             PerfectMoneyTransaction::where('id', $pmTransaction->id)->update(['status' => 'canceled']);
-
             if (config('perfectmoney.pm_fail_callback')) {
                 $callback = config('perfectmoney.pm_fail_callback');
                 $params = ['status' => 'failed', 'payment_id' => $request->get('PAYMENT_ID')];
                 $callback($params);
-                // call_user_func_array(config('perfectmoney.pm_success_function'), $params);
-                // call_user_func(config('perfectmoney.pm_success_function'));
                 return true;
             }
         }
@@ -119,39 +108,39 @@ class Perfectmoney extends PerfectmoneyContract
     public function pmStatus(Request $request)
     {
         $payment_id = $request->get('PAYMENT_ID');
-
         $pmTransaction = PerfectMoneyTransaction::where('payment_id', $payment_id)->where('status', 'banking')->first();
 
-        if(!$pmTransaction){
-        	return abort(422);
+        if (!$pmTransaction) {
+            return abort(422);
         }
-        // define('ALTERNATE_PHRASE_HASH',  setting(''));
 
         // Path to directory to save logs. Make sure it has write permissions.
-        define('PATH_TO_LOG',  '/');
-        $string=
-              $_POST['PAYMENT_ID'].':'.$_POST['PAYEE_ACCOUNT'].':'.
-              $_POST['PAYMENT_AMOUNT'].':'.$_POST['PAYMENT_UNITS'].':'.
-              $_POST['PAYMENT_BATCH_NUM'].':'.
-              $_POST['PAYER_ACCOUNT'].':'.strtoupper(md5($this->alternate_phrase)).':'.
-              $_POST['TIMESTAMPGMT'];
+        define('PATH_TO_LOG', '/');
+        $string =
+            $_POST['PAYMENT_ID'] . ':' . $_POST['PAYEE_ACCOUNT'] . ':' .
+            $_POST['PAYMENT_AMOUNT'] . ':' . $_POST['PAYMENT_UNITS'] . ':' .
+            $_POST['PAYMENT_BATCH_NUM'] . ':' .
+            $_POST['PAYER_ACCOUNT'] . ':' . strtoupper(md5($this->alternate_phrase)) . ':' .
+            $_POST['TIMESTAMPGMT'];
 
-        $hash=strtoupper(md5($string));
-        
+        $hash = strtoupper(md5($string));
+
 
         /* 
            Please use this tool to see how valid hash is generated: 
            https://perfectmoney.is/acct/md5check.html 
         */
-        if($hash==$_POST['V2_HASH']){ // processing payment if only hash is valid
+        if ($hash == $_POST['V2_HASH']) { // processing payment if only hash is valid
 
-           /* In section below you must implement comparing of data you received
-           with data you sent. This means to check if $_POST['PAYMENT_AMOUNT'] is
-           particular amount you billed to client and so on. */
+            /* In section below you must implement comparing of data you received
+            with data you sent. This means to check if $_POST['PAYMENT_AMOUNT'] is
+            particular amount you billed to client and so on. */
 
-           if($_POST['PAYMENT_AMOUNT']==$pmTransaction->payment_amount 
-            && $_POST['PAYEE_ACCOUNT']==$pmTransaction->payee_account 
-            && $_POST['PAYMENT_UNITS']==$pmTransaction->payment_units){
+            if (
+                $_POST['PAYMENT_AMOUNT'] == $pmTransaction->payment_amount
+                && $_POST['PAYEE_ACCOUNT'] == $pmTransaction->payee_account
+                && $_POST['PAYMENT_UNITS'] == $pmTransaction->payment_units
+            ) {
 
                 $pmTransaction->v2_hash = $_POST['V2_HASH'];
                 $pmTransaction->payer_account = $_POST['PAYER_ACCOUNT'];
@@ -172,22 +161,20 @@ class Perfectmoney extends PerfectmoneyContract
                 }
 
                 return 'true';
-           
             }
 
-        }else{ // you can also save invalid payments for debug purposes
+        } else { // you can also save invalid payments for debug purposes
 
-           // uncomment code below if you want to log requests with bad hash
-            $f=fopen('request.log', "ab+");
-           fwrite($f, date("d.m.Y H:i")."; REASON: bad hash; POST: ".serialize($_POST)."; STRING: $string; HASH: $hash\n");
-           fclose($f); 
-           print_r(date("d.m.Y H:i")."; REASON: bad hash; POST: ".serialize($_POST)."; STRING: $string; HASH: $hash\n");
+            // uncomment code below if you want to log requests with bad hash
+            $f = fopen('request.log', "ab+");
+            fwrite($f, date("d.m.Y H:i") . "; REASON: bad hash; POST: " . serialize($_POST) . "; STRING: $string; HASH: $hash\n");
+            fclose($f);
+            print_r(date("d.m.Y H:i") . "; REASON: bad hash; POST: " . serialize($_POST) . "; STRING: $string; HASH: $hash\n");
         }
-
     }
 
-    public function requiredSellParamsCheck($request) {
-        
+    public function requiredSellParamsCheck($request)
+    {
         if (!$this->pm_payee_account) {
             throw InvalidConfiguration::emptyPayeeAccount();
         }
@@ -197,7 +184,6 @@ class Perfectmoney extends PerfectmoneyContract
         }
 
         $request->validate(['payment_id' => 'required|string', 'payment_amount' => 'required|numeric', 'payment_units' => 'required|string']);
-
     }
 
     public function requiredRedeemParamsCheck($request)
@@ -211,63 +197,52 @@ class Perfectmoney extends PerfectmoneyContract
         }
 
         return $request->validate(['vpm_voucher' => 'required|string', 'vpm_activation_code' => 'required|string']);
-
     }
 
-    protected function submit($url, $parameters, $method = "POST"){
+    protected function submit($url, $parameters, $method = "POST")
+    {
 
-        $curl = curl_init( $url );
+        $curl = curl_init($url);
 
         curl_setopt($curl, CURLOPT_VERBOSE, true);
-
         curl_setopt($curl, CURLOPT_POST, true);
-
         curl_setopt($curl, CURLOPT_TIMEOUT, 30);
-
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true); 
-
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_VERBOSE, true);
-
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
 
         $parameters = array_merge($parameters, [
             'AccountID' => $this->pm_account_id,
             'PassPhrase' => $this->pm_account_password,
         ]);
+
         curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($parameters));
 
         $response = curl_exec($curl);
 
-        if (curl_errno($curl)){
-            return ['status'=>'failed','message' => curl_error($curl)];
+        if (curl_errno($curl)) {
+            return ['status' => 'failed', 'message' => curl_error($curl)];
         }
 
-        if (empty($response)){
-            return ['status'=>'failed','message' => 'Connection failed',];
+        if (empty($response)) {
+            return ['status' => 'failed', 'message' => 'Connection failed',];
         }
 
         curl_close($curl);
 
-       $curl = null;
+        $curl = null;
+        $extracted = [];
 
-       $extracted = [];
+        if (!preg_match_all("/<input name='(.*)' type='hidden' value='(.*)'>/", $response, $extracted, PREG_SET_ORDER)) {
+            return ['status' => 'failed', 'message' => 'Invalid input'];
+        }
 
-       if(!preg_match_all("/<input name='(.*)' type='hidden' value='(.*)'>/", $response, $extracted, PREG_SET_ORDER)){
-          return ['status'=>'failed','message'=> 'Invalid input'];
-       }
-
-       $ar= [];
-       foreach($extracted as $item){
-          $key=$item[1];
-          $ar[$key]=$item[2];
-       }
-       // if (in_array('ERROR',array_keys($ar))) {
-       //     return ['status'=>'failed', 'data'=>array_values($ar)];
-       // }
-
-       return ['status'=>'success', 'response' => $ar];
-
+        $ar = [];
+        foreach ($extracted as $item) {
+            $key = $item[1];
+            $ar[$key] = $item[2];
+        }
+        
+        return ['status' => 'success', 'response' => $ar];
     }
 }
-
-?>

--- a/src/Perfectmoney.php
+++ b/src/Perfectmoney.php
@@ -253,7 +253,7 @@ class Perfectmoney extends PerfectmoneyContract
        $extracted = [];
 
        if(!preg_match_all("/<input name='(.*)' type='hidden' value='(.*)'>/", $response, $extracted, PREG_SET_ORDER)){
-          return ['status'=>'failed','message'=> 'Ivalid input'];
+          return ['status'=>'failed','message'=> 'Invalid input'];
        }
 
        $ar= [];

--- a/src/Perfectmoney.php
+++ b/src/Perfectmoney.php
@@ -50,7 +50,7 @@ class Perfectmoney extends PerfectmoneyContract
     	// $order->save();
     	$pmTransaction->save();
 
-    	return ['status'=>'success','action'=>'submit_form','data'=>view('mohsen-nurisa/perfectmoney-laravel::form',compact('pmTransaction'))->render(),'message'=>__('sell_initiated_successfully')];
+    	return ['status'=>'success','action'=>'submit_form','data'=>view('nishad-prime/perfectmoney-laravel::form',compact('pmTransaction'))->render(),'message'=>__('sell_initiated_successfully')];
 
     }
 

--- a/src/PerfectmoneyServiceProvider.php
+++ b/src/PerfectmoneyServiceProvider.php
@@ -14,7 +14,7 @@ class PerfectmoneyServiceProvider extends ServiceProvider
 		$this->loadMigrationsFrom(__DIR__.'/Database/migrations');
 		$this->loadRoutesFrom(__DIR__.'/Routes/web.php');
 
-		$this->loadViewsFrom(__DIR__.'/Views', 'mohsen-nurisa/perfectmoney-laravel');
+		$this->loadViewsFrom(__DIR__.'/Views', 'nishad-prime/perfectmoney-laravel');
 		$this->publishes([
 	        __DIR__.'/Config/perfectmoney.php' => config_path('perfectmoney.php'),
 	    ]);

--- a/src/PerfectmoneyServiceProvider.php
+++ b/src/PerfectmoneyServiceProvider.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+
 namespace Package\Perfectmoney;
 
 use Illuminate\Support\ServiceProvider;
@@ -11,22 +12,21 @@ class PerfectmoneyServiceProvider extends ServiceProvider
 {
 	public function boot()
 	{
-		$this->loadMigrationsFrom(__DIR__.'/Database/migrations');
-		$this->loadRoutesFrom(__DIR__.'/Routes/web.php');
+		$this->loadMigrationsFrom(__DIR__ . '/Database/migrations');
+		$this->loadRoutesFrom(__DIR__ . '/Routes/web.php');
 
-		$this->loadViewsFrom(__DIR__.'/Views', 'nishad-prime/perfectmoney-laravel');
+		$this->loadViewsFrom(__DIR__ . '/Views', 'nishad-prime/perfectmoney-laravel');
 		$this->publishes([
-	        __DIR__.'/Config/perfectmoney.php' => config_path('perfectmoney.php'),
-	    ]);
+			__DIR__ . '/Config/perfectmoney.php' => config_path('perfectmoney.php'),
+		]);
 
-	    $this->app->bind('perfectmoney', function ($app) {
-	        return new Perfectmoney();
-	    });
+		$this->app->bind('perfectmoney', function ($app) {
+			return new Perfectmoney();
+		});
 	}
 
 	public function register()
 	{
-		
+
 	}
 }
-?>

--- a/src/Routes/web.php
+++ b/src/Routes/web.php
@@ -1,23 +1,20 @@
 <?php
 
-Route::group(['prefix'=>'pm', 'as' => 'pm.', 'namespace' => 'Package\Perfectmoney\Controllers'],function(){
-
+Route::group(['prefix' => 'pm', 'as' => 'pm.', 'namespace' => 'Package\Perfectmoney\Controllers'], function () {
 	Route::post('sell', ['as' => 'sell', 'uses' => 'PerfectMoneyController@sell']);
 
 	Route::post('/status', [
-	    'as' => 'pm_status',
-	    'uses' => 'PerfectMoneyController@pmStatus',
+		'as' => 'pm_status',
+		'uses' => 'PerfectMoneyController@pmStatus',
 	]);
 
 	Route::post('/payment', [
-	    'as' => 'pm_payment',
-	    'uses' => 'PerfectMoneyController@pmSuccess',
+		'as' => 'pm_payment',
+		'uses' => 'PerfectMoneyController@pmSuccess',
 	]);
 
 	Route::post('/nopayment', [
-	    'as' => 'pm_nopayment',
-	    'uses' => 'PerfectMoneyController@pmFail',
+		'as' => 'pm_nopayment',
+		'uses' => 'PerfectMoneyController@pmFail',
 	]);
 });
-
-?>

--- a/src/Views/form.blade.php
+++ b/src/Views/form.blade.php
@@ -1,1 +1,8 @@
-<form id='crypto-form' class='form' method='post' action='https://perfectmoney.is/api/step1.asp'><input type='hidden' name='PAYEE_ACCOUNT' value='{{config('perfectmoney.pm_payee_account')}}'><input type='hidden' name='PAYEE_NAME' value='{{env('APP_NAME')}}'><input type='hidden' name='PAYMENT_AMOUNT' value='{{$pmTransaction->payment_amount}}'><input type='hidden' name='PAYMENT_UNITS' value='{{$pmTransaction->payment_units}}'><input type='hidden' name='PAYMENT_ID' value='{{$pmTransaction->payment_id}}'><input type='hidden' name='STATUS_URL' value='{{route('pm.pm_status')}}'><input type='hidden' name='PAYMENT_URL' value='{{route('pm.pm_payment')}}'><input type='hidden' name='NOPAYMENT_URL' value='{{route('pm.pm_nopayment')}}'></form>
+<form id='crypto-form' class='form' method='post' action='https://perfectmoney.is/api/step1.asp'><input type='hidden'
+        name='PAYEE_ACCOUNT' value='{{config(' perfectmoney.pm_payee_account')}}'><input type='hidden' name='PAYEE_NAME'
+        value='{{env(' APP_NAME')}}'><input type='hidden' name='PAYMENT_AMOUNT'
+        value='{{$pmTransaction->payment_amount}}'><input type='hidden' name='PAYMENT_UNITS'
+        value='{{$pmTransaction->payment_units}}'><input type='hidden' name='PAYMENT_ID'
+        value='{{$pmTransaction->payment_id}}'><input type='hidden' name='STATUS_URL' value='{{route('
+        pm.pm_status')}}'><input type='hidden' name='PAYMENT_URL' value='{{route(' pm.pm_payment')}}'><input
+        type='hidden' name='NOPAYMENT_URL' value='{{route(' pm.pm_nopayment')}}'></form>


### PR DESCRIPTION
I like this package because of its simplicity. However, my problem with this package is that it sets the payment ID automatically. That's okay for integrating with websites, but not everyone is using this package to integrate it with a website. It's a dealbreaker for someone who wants the flexibility of setting the `payment_id` by himself. It isn't that hard to generate a random string in Laravel these days. You just have to call `uniqid()` to get a random string that's never the same twice. People who don't care about the `payment_id` will just use that to generate a random `payment_id`. To my knowledge, that shouldn't cause any problems.